### PR TITLE
Fix broken links

### DIFF
--- a/COMP2432/README.md
+++ b/COMP2432/README.md
@@ -1,5 +1,5 @@
 代码贡献01: 2018 年的复习笔记：https://gist.github.com/CrabAss/e6b5cf660bbefb9e303eacfebd876ea9
 
-代码贡献02: https://github.com/darekaze/ug-code-archive.git/courses
+代码贡献02: https://github.com/darekaze/ug-code-archive/tree/master/courses
 
 代码贡献03: https://github.com/ZHANG-CAIQI/COMP2432.git

--- a/COMP3011/README.md
+++ b/COMP3011/README.md
@@ -1,1 +1,1 @@
-代码贡献01: https://github.com/darekaze/ug-code-archive.git/courses
+代码贡献01: https://github.com/darekaze/ug-code-archive/tree/master/courses

--- a/COMP3211/README.md
+++ b/COMP3211/README.md
@@ -1,3 +1,3 @@
 代码贡献 01 : https://github.com/hanshanglin/COMP_3211
 
-代码贡献 02 : https://github.com/darekaze/ug-code-archive.git/courses
+代码贡献 02 : https://github.com/darekaze/ug-code-archive/tree/master/courses

--- a/COMP3334/README.md
+++ b/COMP3334/README.md
@@ -1,1 +1,1 @@
-代码贡献01: https://github.com/darekaze/ug-code-archive.git/courses
+代码贡献01: https://github.com/darekaze/ug-code-archive/tree/master/courses

--- a/COMP3438/README.md
+++ b/COMP3438/README.md
@@ -1,4 +1,4 @@
-代码贡献01: https://github.com/darekaze/ug-code-archive.git/courses
+代码贡献01: https://github.com/darekaze/ug-code-archive/tree/master/courses
 
 
 


### PR DESCRIPTION
All links to https://github.com/darekaze/ug-code-archive.git/courses are broken and replaced with https://github.com/darekaze/ug-code-archive/tree/master/courses